### PR TITLE
IT-36715 / Need to track revision ready to be assembled

### DIFF
--- a/src/main/groovy/assembleAndDeployPipeline.groovy
+++ b/src/main/groovy/assembleAndDeployPipeline.groovy
@@ -12,23 +12,6 @@ pipeline {
     }
 
     stages {
-        // TODO JHE (14.12.2020): Depending on how IT-36715 will be implemented, we might remove this complete stage.
-        stage("Copy Revision file") {
-            steps {
-                lock("revisionFileOperation") {
-                    fileOperations([
-                            folderCreateOperation(folderPath: "${env.WORKSPACE}/clonedInformation"),
-                    ])
-                    dir(env.GRADLE_USER_HOME_PATH) {
-                        fileOperations([
-                                fileCopyOperation(includes: "Revisions.json", targetLocation: "${env.WORKSPACE}/clonedInformation")
-                        ])
-                    }
-
-                }
-            }
-        }
-
         //JHE (14.12.2020): This is not really a stage ... but Jenkins won't accept to have step done before parallel tasks (below)
         stage("Starting logged") {
             steps {


### PR DESCRIPTION
When starting an assembleAndDeploy Job, we don't need anymore to clone the Revisions